### PR TITLE
Board, Menu, and page all use useState passed as props instead of sketchy horizontal state sharing.

### DIFF
--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -4,17 +4,7 @@ import { useState, useEffect } from "react";
 import Square from "./Square";
 type Player = "X" | "O" | "neither of you" | null;
 
-let selected: string = "human v human";
-
-export function getSelected(): string {
-    return selected;
-}
-
-export function setSelected(select: string): void {
-    selected = select;
-}
-
-function Board() {
+function Board({ selected }: { selected: string }) {
     const [squares, setSquares] = useState(Array(9).fill(null));
     const [currentPlayer, setCurrentPlayer] = useState<'X' | 'O'>('X');
     const [winner, setWinner] = useState<Player>(null);

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -1,8 +1,7 @@
 'use client';
 import { useState } from "react";
-import { getSelected, setSelected } from "./Board";
 
-function Menu() {
+function Menu({ selected, setSelected }: { selected: string, setSelected: (val: string | ((prevVal: string) => string)) => void }) {
     const [isOpen, setIsOpen] = useState(false);
     const options = ["human v human", "human v computer"];
 
@@ -12,7 +11,7 @@ function Menu() {
     }
 
     function getClass(val: string): string {
-        if (val === getSelected()) {
+        if (val === selected) {
             return "selected";
         }
         return "not";
@@ -24,7 +23,7 @@ function Menu() {
 
     return (
         <div>
-            <button onClick={() => { dropDownToggle() }}>{getSelected()}</button>
+            <button onClick={() => { dropDownToggle() }}>{selected}</button>
             {isOpen && (
                 <div>
                     {options.map((val: string, ind: number) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,15 @@
+'use client';
 import Board from "../../components/Board";
 import Menu from "../../components/Menu"
+import { useState } from "react";
 
 export default function Home() {
+    const [selected, setSelected] = useState("human v human");
     return (
         <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
             <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-            <Menu />
-            <Board />
+            <Menu selected={selected} setSelected={setSelected}/>
+            <Board selected={selected}/>
             </main>
             </div>
     );


### PR DESCRIPTION
- refactored Board.tsx, Menu.tsx, and page.tsx to have page set up useState
    - pass needed vars to Board and Menu as props 
    - instead of sharing state between sibling components
- testing
    - works for X and O winning for both human v human and human v computer
- pull request